### PR TITLE
Add basic support for version 11

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,7 +419,7 @@ impl Layer {
         let hptr = rdr.read_uint::<BigEndian>(version.bytes_per_offset())?;
         let current_pos = rdr.seek(SeekFrom::Current(0))?;
         rdr.seek(SeekFrom::Start(hptr))?;
-        let pixels = PixelData::parse_heirarchy(&mut rdr, version)?;
+        let pixels = PixelData::parse_hierarchy(&mut rdr, version)?;
         rdr.seek(SeekFrom::Start(current_pos))?;
         // TODO
         // let mptr = rdr.read_uint::<BigEndian>(version.bytes_per_offset())?;
@@ -428,7 +428,7 @@ impl Layer {
         })
     }
 
-    pub fn pixel(&self, x: usize, y: usize) -> Option<RgbaPixel> {
+    pub fn pixel(&self, x: u32, y: u32) -> Option<RgbaPixel> {
         self.pixels.pixel(x, y)
     }
 
@@ -440,7 +440,7 @@ impl Layer {
         Cow::from(&self.pixels.pixels)
     }
 
-    pub fn raw_sub_rgba_buffer(&self, x: usize, y: usize, width: usize, height: usize) -> Vec<u8> {
+    pub fn raw_sub_rgba_buffer(&self, x: u32, y: u32, width: u32, height: u32) -> Vec<u8> {
         self.pixels.raw_sub_rgba_buffer(x, y, width, height)
     }
 }
@@ -464,19 +464,19 @@ impl LayerColorType {
 // TODO: Make this an enum? We should store a buffer that matches the channels present.
 #[derive(Clone, Debug, PartialEq)]
 pub struct PixelData {
-    width: usize,
-    height: usize,
-    pixels: Vec<RgbaPixel>
+    pub width: u32,
+    pub height: u32,
+    pub pixels: Vec<RgbaPixel>
 }
 
 impl PixelData {
     /// Parses the (silly?) heirarchy structure in the xcf file into a pixel array
     /// Makes lots of assumptions! Only supports RGBA for now.
-    fn parse_heirarchy<R: Read + Seek>(mut rdr: R, version: Version) -> Result<PixelData, Error> {
+    fn parse_hierarchy<R: Read + Seek>(mut rdr: R, version: Version) -> Result<PixelData, Error> {
         // read the heirarchy
-        let width = rdr.read_u32::<BigEndian>()? as usize;
-        let height = rdr.read_u32::<BigEndian>()? as usize;
-        let bpp = rdr.read_u32::<BigEndian>()? as usize;
+        let width = rdr.read_u32::<BigEndian>()?;
+        let height = rdr.read_u32::<BigEndian>()?;
+        let bpp = rdr.read_u32::<BigEndian>()?;
         if bpp != 3 && bpp != 4 {
             return Err(Error::NotSupported);
         }
@@ -484,8 +484,8 @@ impl PixelData {
         let _dummpy_ptr_pos = rdr.seek(SeekFrom::Current(0))?;
         rdr.seek(SeekFrom::Start(lptr))?;
         // read the level
-        let level_width = rdr.read_u32::<BigEndian>()? as usize;
-        let level_height = rdr.read_u32::<BigEndian>()? as usize;
+        let level_width = rdr.read_u32::<BigEndian>()?;
+        let level_height = rdr.read_u32::<BigEndian>()?;
         if level_width != width || level_height != height {
             return Err(Error::InvalidFormat);
         }
@@ -493,8 +493,8 @@ impl PixelData {
         let mut pixels = vec![RgbaPixel([0, 0, 0, 255]); (width * height) as usize];
         let mut next_tptr_pos;
 
-        let tiles_x = (width as f32 / 64.0).ceil() as usize;
-        let tiles_y = (height as f32 / 64.0).ceil() as usize;
+        let tiles_x = (f64::from(width) / 64.0).ceil() as u32;
+        let tiles_y = (f64::from(height) / 64.0).ceil() as u32;
         for ty in 0..tiles_y {
             for tx in 0..tiles_x {
                 let tptr = rdr.read_uint::<BigEndian>(version.bytes_per_offset())?;
@@ -522,11 +522,11 @@ impl PixelData {
         Ok(PixelData { pixels, width, height })
     }
 
-    pub fn pixel(&self, x: usize, y: usize) -> Option<RgbaPixel> {
+    pub fn pixel(&self, x: u32, y: u32) -> Option<RgbaPixel> {
         if x >= self.width || y >= self.height {
             return None;
         }
-        Some(self.pixels[y * self.width + x])
+        Some(self.pixels[(y * self.width + x) as usize])
     }
 
     /// Creates a raw sub buffer from self.
@@ -534,8 +534,8 @@ impl PixelData {
     /// # Panics
     ///
     /// Panics if a pixel access is out of bounds.
-    pub fn raw_sub_rgba_buffer(&self, x: usize, y: usize, width: usize, height: usize) -> Vec<u8> {
-        let mut sub = Vec::with_capacity(width * height * 4);
+    pub fn raw_sub_rgba_buffer(&self, x: u32, y: u32, width: u32, height: u32) -> Vec<u8> {
+        let mut sub = Vec::with_capacity((width * height * 4) as usize);
         for _y in y..(y + height) {
             for _x in x..(x + width) {
                 if _y > self.height || _x > self.width {
@@ -544,17 +544,17 @@ impl PixelData {
                 sub.extend_from_slice(&self.pixel(_x, _y).unwrap().0);
             }
         }
-        return sub
+        sub
     }
 }
 
 pub struct TileCursor {
-    width: usize,
-    height: usize,
-    channels: usize,
-    x: usize,
-    y: usize,
-    i: usize,
+    width: u32,
+    height: u32,
+    channels: u32,
+    x: u32,
+    y: u32,
+    i: u32,
 }
 
 // TODO: I like the use of a struct but this isn't really any kind of cursor.
@@ -562,7 +562,7 @@ pub struct TileCursor {
 // stuff we need to store within the "algorithm." A better design is very welcome! i should be
 // moved into feed as a local.
 impl TileCursor {
-    fn new(width: usize, height: usize, tx: usize, ty: usize, channels: usize) -> TileCursor {
+    fn new(width: u32, height: u32, tx: u32, ty: u32, channels: u32) -> TileCursor {
         TileCursor {
             width,
             height,
@@ -582,37 +582,37 @@ impl TileCursor {
         let mut channel = 0;
         while channel < self.channels {
             while self.i < twidth * theight {
-                let determinant = rdr.read_u8()? as u32;
+                let determinant = rdr.read_u8()?;
                 if determinant < 127 { // A short run of identical bytes
-                    let run = (determinant + 1) as usize;
+                    let run = u32::from(determinant + 1);
                     let v = rdr.read_u8()?;
                     for i in (self.i)..(self.i + run) {
                         let index = base_offset + (i / twidth) * self.width + i % twidth;
-                        pixels[index].0[channel] = v;
+                        pixels[index as usize].0[channel as usize] = v;
                     }
                     self.i += run;
                 } else if determinant == 127 { // A long run of identical bytes
-                    let run = rdr.read_u16::<BigEndian>()? as usize;
+                    let run = u32::from(rdr.read_u16::<BigEndian>()?);
                     let v = rdr.read_u8()?;
                     for i in (self.i)..(self.i + run) {
                         let index = base_offset + (i / twidth) * self.width + i % twidth;
-                        pixels[index].0[channel] = v;
+                        pixels[index as usize].0[channel as usize] = v;
                     }
                     self.i += run;
                 } else if determinant == 128 { // A long run of different bytes
-                    let stream_run = rdr.read_u16::<BigEndian>()? as usize;
+                    let stream_run = u32::from(rdr.read_u16::<BigEndian>()?);
                     for i in (self.i)..(self.i + stream_run) {
                         let index = base_offset + (i / twidth) * self.width + i % twidth;
                         let v = rdr.read_u8()?;
-                        pixels[index].0[channel] = v;
+                        pixels[index as usize].0[channel as usize] = v;
                     }
                     self.i += stream_run;
                 } else { // A short run of different bytes
-                    let stream_run = (256 - determinant) as usize;
+                    let stream_run = 256 - u32::from(determinant);
                     for i in (self.i)..(self.i + stream_run) {
                         let index = base_offset + (i / twidth) * self.width + i % twidth;
                         let v = rdr.read_u8()?;
-                        pixels[index].0[channel] = v;
+                        pixels[index as usize].0[channel as usize] = v;
                     }
                     self.i += stream_run;
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl Property {
 macro_rules! prop_ident_gen {
     (
         pub enum PropertyIdentifier {
-            Unknown,
+            Unknown(u32),
             $(
                 $prop:ident = $val:expr
             ),+,
@@ -234,7 +234,7 @@ macro_rules! prop_ident_gen {
             // we have to put this at the end, since otherwise it will try to have value zero,
             // we really don't care what it is as long as it doesn't conflict with anything else
             // (however in the macro we have to put it first since it's a parsing issue)
-            Unknown,
+            Unknown(u32),
         }
 
         impl PropertyIdentifier {
@@ -243,7 +243,7 @@ macro_rules! prop_ident_gen {
                     $(
                         $val => PropertyIdentifier::$prop
                     ),+,
-                    _ => PropertyIdentifier::Unknown,
+                    _ => PropertyIdentifier::Unknown(prop),
                 }
             }
         }
@@ -252,19 +252,33 @@ macro_rules! prop_ident_gen {
 
 prop_ident_gen! {
     pub enum PropertyIdentifier {
-        Unknown,
+        Unknown(u32),
         PropEnd = 0,
         PropColormap = 1,
+        PropActiveLayer = 2,
         PropOpacity = 6,
+        PropMode = 7,
         PropVisible = 8,
         PropLinked = 9,
+        PropLockAlpha = 10,
+        PropApplyMask = 11,
+        PropEditMask = 12,
+        PropShowMask = 13,
+        PropOffsets = 15,
         PropCompression = 17,
         TypeIdentification = 18,
         PropResolution = 19,
         PropTattoo = 20,
         PropParasites = 21,
+        PropUnit = 22,
         PropPaths = 23,
         PropLockContent = 28,
+        PropLockPosition = 32,
+        PropFloatOpacity = 33,
+        PropColorTag = 34,
+        PropCompositeMode = 35,
+        PropCompositeSpace = 36,
+        PropBlendSpace = 37,
     }
 }
 


### PR DESCRIPTION
Hi, thanks for the crate! It didn't work for me when I tried it on the files produced by the current GIMP which turned out to be version 11 so I hacked the crate a little bit to make it work. I didn't do much, basically just enough to load my files, but I think it's useful anyway!